### PR TITLE
Switch babel preset order

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "neutrino-preset-mozilla-rpweb",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "main": "src/index.js",
   "repository": "mozilla-rpweb/neutrino-preset-mozilla-rpweb",
   "author": "Eli Perelman <eli@eliperelman.com>",
@@ -11,8 +11,8 @@
   "dependencies": {
     "babel-preset-stage-2": "^6.22.0",
     "deepmerge": "^1.3.2",
-    "neutrino-preset-airbnb-base": "^4.0.1",
-    "neutrino-preset-react": "^4.0.1"
+    "neutrino-preset-airbnb-base": "^4.1.1",
+    "neutrino-preset-react": "^4.1.0"
   },
   "peerDependencies": {
     "neutrino": "^4.0.0"

--- a/src/index.js
+++ b/src/index.js
@@ -90,7 +90,7 @@ module.exports = neutrino => {
   neutrino.config.module
     .rule('compile')
     .loader('babel', ({ options }) => {
-      options.presets.unshift(require.resolve('babel-preset-stage-2'));
+      options.presets.push(require.resolve('babel-preset-stage-2'));
 
       return { options };
     });

--- a/yarn.lock
+++ b/yarn.lock
@@ -3150,32 +3150,39 @@ negotiator@0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/negotiator/-/negotiator-0.6.1.tgz#2b327184e8992101177b28563fb5e7102acd0ca9"
 
-neutrino-preset-airbnb-base@^4.0.1:
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/neutrino-preset-airbnb-base/-/neutrino-preset-airbnb-base-4.0.1.tgz#2d58b8a164be1e2628e1bd3b811e07972bf892d6"
+neutrino-lint-base@4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/neutrino-lint-base/-/neutrino-lint-base-4.1.0.tgz#9eafb2c89ea46119c3787af8647c8b305273f187"
   dependencies:
     babel-eslint "^7.1.1"
     eslint "^3.14.1"
-    eslint-config-airbnb-base "^11.1.0"
     eslint-loader "^1.6.1"
     eslint-plugin-babel "^4.0.1"
     eslint-plugin-import "^2.2.0"
 
-neutrino-preset-react@^4.0.1:
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/neutrino-preset-react/-/neutrino-preset-react-4.0.1.tgz#a2f49c555d62f6cf021b597568413f0e516f2de5"
+neutrino-preset-airbnb-base@^4.1.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/neutrino-preset-airbnb-base/-/neutrino-preset-airbnb-base-4.1.1.tgz#c9de202a27c791c974b11e919f60daea67dc63ce"
+  dependencies:
+    deepmerge "^1.3.2"
+    eslint-config-airbnb-base "^11.1.0"
+    neutrino-lint-base "4.1.0"
+
+neutrino-preset-react@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/neutrino-preset-react/-/neutrino-preset-react-4.1.0.tgz#753ca83749b0c182bb91de991a91de0d3664b31a"
   dependencies:
     babel-plugin-transform-object-rest-spread "^6.22.0"
     babel-preset-react "^6.22.0"
     deepmerge "^1.3.2"
     eslint-plugin-react "^6.9.0"
-    neutrino-preset-web "4.0.0"
+    neutrino-preset-web "4.0.1"
     react-hot-loader "^3.0.0-beta.6"
     webpack "^2.2.1"
 
-neutrino-preset-web@4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/neutrino-preset-web/-/neutrino-preset-web-4.0.0.tgz#e7790a2541186d6ce9801e01473cfe0f3d28614b"
+neutrino-preset-web@4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/neutrino-preset-web/-/neutrino-preset-web-4.0.1.tgz#93fda508481d731938c408cfb60e401974089925"
   dependencies:
     babel-core "^6.22.1"
     babel-loader "^6.2.10"
@@ -3352,13 +3359,7 @@ on-headers@~1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/on-headers/-/on-headers-1.0.1.tgz#928f5d0f470d49342651ea6794b0857c100693f7"
 
-once@^1.3.0:
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/once/-/once-1.4.0.tgz#583b1aa775961d4b113ac17d9c50baef9dd76bd1"
-  dependencies:
-    wrappy "1"
-
-once@~1.3.3:
+once@^1.3.0, once@~1.3.3:
   version "1.3.3"
   resolved "https://registry.yarnpkg.com/once/-/once-1.3.3.tgz#b2e261557ce4c314ec8304f3fa82663e4297ca20"
   dependencies:


### PR DESCRIPTION
Turns out Babel loads last-to-first, meaning stage-2 needs to be listed **after** preset-env in order to load **before** preset-env.