### PR TITLE
Add trailing commas back to align with airbnb

### DIFF
--- a/index.js
+++ b/index.js
@@ -30,8 +30,6 @@ module.exports = (neutrino, options = {}) => {
         // Allow using class methods with static/non-instance functionality
         // React lifecycle methods commonly do not use an instance context for anything
         'class-methods-use-this': 'off',
-        // Disallow trailing commas on arrays, objects, functions, et al
-        'comma-dangle': ['error', 'never'],
         // Prefer double or quotes in JSX attributes
         // http://eslint.org/docs/rules/jsx-quotes
         'jsx-quotes': ['error', 'prefer-double'],


### PR DESCRIPTION
Maintaining 2 comma systems, one based on airbnb, the other based on deviations from it, in a single repo is a little cumbersome. I am proposing moving back to trailing commas to make this easier, and more familiar to those who expect it to act like airbnb.