### PR TITLE
Only pull components from JSX files

### DIFF
--- a/styleguide.js
+++ b/styleguide.js
@@ -11,7 +11,7 @@ module.exports = (neutrino, opts = {}) => {
     {
       components: join(
         basename(neutrino.options.source),
-        'components/**/*.{js,jsx}'
+        'components/**/*.jsx'
       ),
       require: addBabelPolyfill ? ['babel-polyfill'] : [],
       showUsage: true,


### PR DESCRIPTION
Since we use the Airbnb preset, all our components are in JSX files, leaving JS files to be used for other purposes. As such, this confuses the styleguide middleware, since it is trying to find components in JS files but can't find any.