### PR TITLE
Add command for easing setup and usage of linting staged files

### DIFF
--- a/.neutrinorc.js
+++ b/.neutrinorc.js
@@ -4,5 +4,6 @@ module.exports = {
   },
   use: [
     './node-lint',
+    './stage',
   ],
 };

--- a/bin/install.js
+++ b/bin/install.js
@@ -1,0 +1,5 @@
+#! /usr/bin/env node
+
+const { spawn } = require('child_process');
+
+spawn(require.resolve('husky/bin/install'), [], { stdio: 'inherit' });

--- a/bin/uninstall.js
+++ b/bin/uninstall.js
@@ -1,0 +1,5 @@
+#! /usr/bin/env node
+
+const { spawn } = require('child_process');
+
+spawn(require.resolve('husky/bin/uninstall'), [], { stdio: 'inherit' });

--- a/node.js
+++ b/node.js
@@ -4,6 +4,7 @@ const decorators = require('./decorators');
 const versioning = require('./versioning');
 const devtool = require('./devtool');
 const localModules = require('./local-modules');
+const stage = require('./stage');
 
 module.exports = (neutrino, options = {}) => {
   neutrino.use(lint, options.eslint);
@@ -12,4 +13,5 @@ module.exports = (neutrino, options = {}) => {
   neutrino.use(versioning, { cacheVersion: options.cacheVersion });
   neutrino.use(devtool);
   neutrino.use(localModules);
+  neutrino.use(stage, options.staging);
 };

--- a/package.json
+++ b/package.json
@@ -6,10 +6,9 @@
   "license": "MPL-2.0",
   "scripts": {
     "lint": "neutrino lint",
-    "precommit": "lint-staged"
-  },
-  "lint-staged": {
-    "*.js": "neutrino lint"
+    "precommit": "neutrino stage",
+    "install": "node ./bin/install",
+    "uninstall": "node ./bin/uninstall"
   },
   "dependencies": {
     "@neutrinojs/airbnb": "^8.1.2",
@@ -25,6 +24,8 @@
     "deepmerge": "^1.5.2",
     "eslint-config-prettier": "^2.9.0",
     "eslint-plugin-prettier": "^2.6.0",
+    "husky": "^0.14.3",
+    "lint-staged": "^7.0.0",
     "neutrino-middleware-styleguidist": "^1.0.2",
     "prettier": "^1.11.1"
   },
@@ -32,8 +33,6 @@
     "neutrino": "^8.0.0"
   },
   "devDependencies": {
-    "husky": "^0.14.3",
-    "lint-staged": "^7.0.0",
     "neutrino": "^8.1.2"
   }
 }

--- a/react-components.js
+++ b/react-components.js
@@ -3,6 +3,7 @@ const lint = require('./react-lint');
 const decorators = require('./decorators');
 const devtool = require('./devtool');
 const localModules = require('./local-modules');
+const stage = require('./stage');
 
 const reactComponents = require.resolve('@neutrinojs/react-components');
 
@@ -24,4 +25,5 @@ module.exports = (neutrino, options = {}) => {
   });
   neutrino.use(decorators);
   neutrino.use(localModules);
+  neutrino.use(stage, options.staging);
 };

--- a/react.js
+++ b/react.js
@@ -5,6 +5,7 @@ const rhl = require('./rhl');
 const versioning = require('./versioning');
 const devtool = require('./devtool');
 const localModules = require('./local-modules');
+const stage = require('./stage');
 
 module.exports = (neutrino, options = {}) => {
   neutrino.use(lint, options.eslint);
@@ -14,4 +15,5 @@ module.exports = (neutrino, options = {}) => {
   neutrino.use(versioning, { cacheVersion: options.cacheVersion });
   neutrino.use(devtool);
   neutrino.use(localModules);
+  neutrino.use(stage, options.staging);
 };

--- a/stage.js
+++ b/stage.js
@@ -1,0 +1,41 @@
+const merge = require('deepmerge');
+const runAll = require('lint-staged/src/runAll');
+const printErrors = require('lint-staged/src/printErrors');
+
+module.exports = (neutrino, opts = {}) => {
+  if (neutrino.options.command === 'stage') {
+    global.interactive = false;
+  }
+
+  const options = merge(
+    {
+      concurrent: true,
+      chunkSize: Number.MAX_SAFE_INTEGER,
+      globOptions: {
+        matchBase: true,
+        dot: true,
+      },
+      linters: {},
+      ignore: [],
+      subTaskConcurrency: 1,
+      renderer: 'update',
+    },
+    opts
+  );
+
+  if (!Object.keys(options.linters).length) {
+    options.linters['*.{js,jsx}'] = ['neutrino lint'];
+  }
+
+  neutrino.register(
+    'stage',
+    () =>
+      runAll(options)
+        .then(() => process.exit())
+        .catch(error => {
+          printErrors(error);
+          process.exit(1);
+        }),
+    'Run commands on git staged files using lint-staged'
+  );
+};


### PR DESCRIPTION
I almost didn't believe something like this would work, but crazily enough, it does!

Install the preset, add the script hook, that's it:

---

```bash
yarn add --dev neutrino-preset-mozilla-frontend-infra
```

```json
{
  "scripts": {
    "precommit": "neutrino stage"
  }
}
```

```js
// src/index.js
console.log('linting error')
```

```bash
git commit -m "linting error"

# commit fails :)
```